### PR TITLE
fix: add rust-src component to enable lsp support fo std library 

### DIFF
--- a/hls-server/rust-toolchain.toml
+++ b/hls-server/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.85.0"
-components = [ "rust-analyzer", "clippy", "rustfmt" ]
+components = ["rust-analyzer", "clippy", "rustfmt", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
# Summary

Add `rust-src` component to `rust-toolchain.toml`. This tells fenix to install 
the Rust source code, which allows rust-analyzer to provide autocomplete for 
Rust's standard library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain configuration to include additional source components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->